### PR TITLE
Add root user requirement to image requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains the source files for supported base images. These image
 Contributions to this repository are welcome in the form of pull requests. Each base image should be placed in a separate directory in the top-level directory of this repo. Those image-specific directories should contain a file named `Dockerfile` and any other files needed to build the image. For a base image to be valid, it must meet the following requirements:
 - A user named `autograder` must exist
 - A directory of `/home/autograder/working_dir` must be set as the image's `WORKDIR` and must be owned by the autograder user. 
+- The image must enter via user `root`.
 - Python 3.5 or greater must be installed and available on the system PATH.
 
 The following `Dockerfile` snippet accomplishes this for Ubuntu 16:


### PR DESCRIPTION
Hi! While working to set up a new Docker image recently, I ran into a requirement that seems to be implicit—that the container enters via the `root` user. I had attempted to enter via the `autograder` user (after doing some user-level setup), and was greeted with the red skull; after throwing in a `USER root`, things were able to proceed normally, so it seems to me that this should be an explicit requirement.