### PR TITLE
Add base image for Ubuntu 20.04 Focal Fossa

### DIFF
--- a/ubuntu20/Dockerfile
+++ b/ubuntu20/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:focal
+
+RUN apt-get update --fix-missing
+RUN apt-get install -y build-essential
+RUN apt-get install -y python3 python3-pip
+
+RUN mkdir -p /home/autograder/working_dir
+
+RUN useradd autograder && \
+   mkdir -p /home/autograder/working_dir && \
+   chown -R autograder:autograder /home/autograder
+
+WORKDIR /home/autograder/working_dir


### PR DESCRIPTION
I have created a base image for Focal Fossa which is the current Ubuntu LTS.