### PR TITLE
Add Ubuntu 22.04 base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ This section lists the tags for each supported base image.
 `eecsautograder/ubuntu16:latest`: Based on Ubuntu 16 (Xenial)
 
 `eecsautograder/ubuntu18:latest`: Based on Ubuntu 18 (Bionic)
+
+`eecsautograder/ubuntu20:latest`: Based on Ubuntu 20 (Focal)
+
+`eecsautograder/ubuntu22:latest`: Based on Ubuntu 22 (Jammy)

--- a/ubuntu22/Dockerfile
+++ b/ubuntu22/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:jammy
+
+RUN apt-get update --fix-missing
+RUN apt-get install -y build-essential
+RUN apt-get install -y python3 python3-pip
+
+RUN mkdir -p /home/autograder/working_dir
+
+RUN useradd autograder && \
+   mkdir -p /home/autograder/working_dir && \
+   chown -R autograder:autograder /home/autograder
+
+WORKDIR /home/autograder/working_dir
+
+CMD ["/bin/bash"]
+


### PR DESCRIPTION
I saw #3 adding an Ubuntu 20.04 base image (which was created in response to #2). But since #2 was opened, Ubuntu 22.04 was released, so I think we should also support this version on the autograder.